### PR TITLE
Properly call notify_property_list_changed when a value is set

### DIFF
--- a/scripts/inspector_property.gd
+++ b/scripts/inspector_property.gd
@@ -107,7 +107,9 @@ func is_editable() -> bool:
 
 
 func set_value(new_value: Variant) -> void:
-	get_object().set(get_property(), new_value)
+	if get_object().get(get_property()) != new_value:
+		get_object().set(get_property(), new_value)
+		get_object().notify_property_list_changed()
 
 func get_value() -> Variant:
 	return get_object().get(get_property())


### PR DESCRIPTION
This allows property changes to be monitored by detecting the `Object.property_list_changed` signal, as you could with the Godot inspector.